### PR TITLE
Fix require.resolve and requiring non-bundled modules

### DIFF
--- a/bundle-dependencies.js
+++ b/bundle-dependencies.js
@@ -63,7 +63,7 @@ function load (filename, parent) {
   let threw = true
   try {
     const { dirname, compiledWrapper } = files.get(filename)
-    const require = makeRequireFunction(module)
+    const require = makeRequireFunction(module, dirname)
     const args = [module.exports, require, module, filename, dirname]
     compiledWrapper.apply(module.exports, args)
     threw = false
@@ -76,7 +76,8 @@ function load (filename, parent) {
   return module.exports
 }
 
-function makeRequireFunction(module) {
+let resolveFrom;
+function makeRequireFunction(module, dirname) {
   const Module = module.constructor
 
   function require (path) {
@@ -84,11 +85,14 @@ function makeRequireFunction(module) {
       return load(path, module)
     }
 
-    return module.require(path)
+    return module.require(resolve(path))
   }
 
   function resolve (request) {
-    return Module._resolveFilename(request, module)
+    if (!resolveFrom) {
+      resolveFrom = module.require(${JSON.stringify(require.resolve('resolve-from'))});
+    }
+    return resolveFrom(dirname, request)
   }
   require.resolve = resolve
 


### PR DESCRIPTION
Use resolve-from to resolve dependencies relative to the module's
directory. Resolve non-bundled dependencies before requiring them, which
actually makes it work.

Note that resolve-from itself cannot be bundled since it has
non-bundled dependencies. To load those dependencies they need to be
resolved, which requires resolve-from.

(That said, it only has built-in dependencies so those could be made
to skip resolve-from, if it's a performance concern.)
